### PR TITLE
Added option to use git command to move (rename) directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ It should be executed from inside root of Xcode project directory and called wit
 
 Script goes through all the files and directories recursively, including Xcode project or workspace file and replaces all occurrences of **$OLD_PROJECT_NAME** string with **$NEW_PROJECT_NAME** string (both in each file's name and content).
 
+Renaming of project directory and Xcode project/workspace defaults to use FileManager.
+For git-managed projects, append optional flag `--use-git` to leverage `git mv $OLD $NEW` instead.
+
 ## Usage
 
 ```bash
@@ -15,6 +18,7 @@ $ curl https://raw.githubusercontent.com/appculture/xcode-project-renamer/master
 
 # run script
 $ ./rename.swift "$OLD_PROJECT_NAME" "$NEW_PROJECT_NAME"
+# $ ./rename.swift "$OLD_PROJECT_NAME" "$NEW_PROJECT_NAME" --use-git
 
 # remove script
 $ rm rename.swift


### PR DESCRIPTION
Original version worked great but renaming directories outside of git caused lots of headache when preparing for next commit. This change implements an optional command-line flag to allow git to do the moving - so it tracks the name changes better.  Also updated the README to reflect alternate usage.  Hope this makes a useful addition to the tool.  As this is my first community contribution, any feedback/suggestion is appreciated.